### PR TITLE
Cul 22 백엔드 문화정보목록 조회 배치 개발

### DIFF
--- a/CultureSpot-Api/build.gradle
+++ b/CultureSpot-Api/build.gradle
@@ -1,7 +1,15 @@
+bootJar.enabled = false
+
 dependencies {
 
     implementation project(':CultureSpot-Domain')
     implementation project(':CultureSpot-Common')
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+    implementation group: 'jakarta.xml.bind', name: 'jakarta.xml.bind-api', version: '4.0.2'
+
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.15.3'
+    implementation 'com.fasterxml:jackson-xml-databind:0.6.2'
 }
 
 tasks.register("prepareKotlinBuildScriptModel"){}

--- a/CultureSpot-Api/src/main/java/com/culturespot/culturespotapi/api/BatchApiService.java
+++ b/CultureSpot-Api/src/main/java/com/culturespot/culturespotapi/api/BatchApiService.java
@@ -1,0 +1,12 @@
+package com.culturespot.culturespotapi.api;
+
+import com.culturespot.culturespotdomain.performance.dto.PerformanceResponse;
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URISyntaxException;
+
+public interface BatchApiService {
+
+	PerformanceResponse performanceOpenApiCall(int pageNo, int numOfRows) throws UnsupportedEncodingException, URISyntaxException, JsonProcessingException;
+}

--- a/CultureSpot-Api/src/main/java/com/culturespot/culturespotapi/api/BatchApiServiceImpl.java
+++ b/CultureSpot-Api/src/main/java/com/culturespot/culturespotapi/api/BatchApiServiceImpl.java
@@ -1,0 +1,65 @@
+package com.culturespot.culturespotapi.api;
+
+import com.culturespot.culturespotapi.config.OpenApiProperties;
+import com.culturespot.culturespotdomain.performance.dto.PerformanceResponse;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+@Slf4j
+@Service
+public class BatchApiServiceImpl implements BatchApiService {
+
+	private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+	private final WebClient webClient;
+	private final XmlMapper xmlMapper;
+	private final OpenApiProperties properties;
+
+	public BatchApiServiceImpl(WebClient.Builder webClientBuilder, OpenApiProperties properties) {
+		this.webClient = webClientBuilder.build();
+		this.xmlMapper = new XmlMapper();
+		this.xmlMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+		this.properties = properties;
+	}
+
+	@Override
+	public PerformanceResponse performanceOpenApiCall(int pageNo, int numOfRows) throws URISyntaxException, JsonProcessingException {
+
+		LocalDate start = LocalDate.now();
+		LocalDate end = start.plusDays(7);
+
+		String startDate = start.format(DATE_FORMATTER);
+		String endDate = end.format(DATE_FORMATTER);
+
+		String encodedServiceKey = URLEncoder.encode(properties.getKey(), StandardCharsets.UTF_8);
+		String url = properties.getApiCall() + "serviceKey=" +
+				encodedServiceKey +
+				"&PageNo=" + pageNo +
+				"&numOfrows=" + numOfRows +
+				"&from=" + startDate +
+				"&to=" + endDate;
+		System.out.println(url);
+
+		URI uri = new URI(url);
+
+		String xmlResponse = webClient.get()
+				.uri(uri)
+				.retrieve()
+				.bodyToMono(String.class)
+				.timeout(Duration.ofSeconds(60))
+				.block();
+		return xmlMapper.readValue(xmlResponse, PerformanceResponse.class);
+	}
+}

--- a/CultureSpot-Api/src/main/java/com/culturespot/culturespotapi/config/JacksonConfig.java
+++ b/CultureSpot-Api/src/main/java/com/culturespot/culturespotapi/config/JacksonConfig.java
@@ -1,0 +1,35 @@
+package com.culturespot.culturespotapi.config;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.dataformat.xml.JacksonXmlModule;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JacksonConfig {
+
+	@Bean
+	public ObjectMapper objectMapper() {
+		ObjectMapper objectMapper = new ObjectMapper();
+		objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+		objectMapper.configure(SerializationFeature.INDENT_OUTPUT, true);
+		objectMapper.configure(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT, true);
+		return objectMapper;
+	}
+
+	@Bean
+	public XmlMapper xmlMapper() {
+		JacksonXmlModule xmlModule = new JacksonXmlModule();
+		xmlModule.setDefaultUseWrapper(false);
+
+		XmlMapper xmlMapper = new XmlMapper(xmlModule);
+		xmlMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+		xmlMapper.configure(SerializationFeature.INDENT_OUTPUT, true);
+		xmlMapper.configure(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT, true);
+
+		return xmlMapper;
+	}
+}

--- a/CultureSpot-Api/src/main/java/com/culturespot/culturespotapi/config/OpenApiProperties.java
+++ b/CultureSpot-Api/src/main/java/com/culturespot/culturespotapi/config/OpenApiProperties.java
@@ -1,0 +1,15 @@
+package com.culturespot.culturespotapi.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "open-api")
+public class OpenApiProperties {
+	private String key;
+	private String apiCall;
+}

--- a/CultureSpot-Api/src/main/java/com/culturespot/culturespotapi/config/WebClientConfig.java
+++ b/CultureSpot-Api/src/main/java/com/culturespot/culturespotapi/config/WebClientConfig.java
@@ -1,0 +1,37 @@
+package com.culturespot.culturespotapi.config;
+
+import io.netty.channel.ChannelOption;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+
+import java.time.Duration;
+
+@Configuration
+public class WebClientConfig {
+
+	@Value("${open-api.base-url}")
+	private String baseUrl;
+
+	@Bean
+	public WebClient.Builder webClientBuilder() {
+		return WebClient.builder()
+				.baseUrl(baseUrl)
+				.defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_XML_VALUE)
+				.codecs(configurer -> {
+					configurer.defaultCodecs().maxInMemorySize(16 * 1024 * 1024);
+				})
+				.clientConnector(new ReactorClientHttpConnector(
+						HttpClient.create()
+								.responseTimeout(Duration.ofSeconds(60))
+								.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 15000)
+								.option(ChannelOption.SO_KEEPALIVE, true)
+								.compress(true)
+				));
+	}
+}

--- a/CultureSpot-Batch/build.gradle
+++ b/CultureSpot-Batch/build.gradle
@@ -1,7 +1,36 @@
+bootJar.enabled = false
+
 dependencies {
 
+    implementation project(':CultureSpot-Api')
     implementation project(':CultureSpot-Domain')
     implementation project(':CultureSpot-Common')
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'org.springframework.boot:spring-boot-starter-quartz'
+    implementation 'org.springframework.boot:spring-boot-starter-batch'
+    testImplementation 'org.springframework.batch:spring-batch-test'
+
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.15.3'
+
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.register("prepareKotlinBuildScriptModel"){}
+
+
+def querydslDir = "$buildDir/generated/querydsl"
+
+sourceSets {
+    main.java.srcDirs += [ querydslDir ]
+}
+
+tasks.withType(JavaCompile) {
+    options.annotationProcessorGeneratedSourcesDirectory = file(querydslDir)
+}
+
+clean.doLast {
+    file(querydslDir).deleteDir()
+}

--- a/CultureSpot-Batch/src/main/java/com/culturespot/culturespotbatch/CultureSpotBatchApplication.java
+++ b/CultureSpot-Batch/src/main/java/com/culturespot/culturespotbatch/CultureSpotBatchApplication.java
@@ -2,12 +2,20 @@ package com.culturespot.culturespotbatch;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
+@ComponentScan(basePackages = {
+		"com.culturespot.culturespotbatch",
+		"com.culturespot.culturespotapi",
+		"com.culturespot.culturespotdomain",
+		"com.culturespot.culturespotcommon"
+})
 public class CultureSpotBatchApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(CultureSpotBatchApplication.class, args);
 	}
-
 }

--- a/CultureSpot-Batch/src/main/java/com/culturespot/culturespotbatch/alarm/BatchResultToDiscord.java
+++ b/CultureSpot-Batch/src/main/java/com/culturespot/culturespotbatch/alarm/BatchResultToDiscord.java
@@ -1,0 +1,57 @@
+package com.culturespot.culturespotbatch.alarm;
+
+import com.culturespot.culturespotcommon.exception.DiscordException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobExecutionListener;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Slf4j
+@Component
+public class BatchResultToDiscord implements JobExecutionListener {
+
+	@Value("${discord.webhook}")
+	private String webHook;
+
+	@Override
+	public void beforeJob(JobExecution jobExecution) {
+		sendDiscordMessage(
+				"배치 작업 시작",
+				"배치 작업 전",
+				0x3498DB // 파란색
+		);
+	}
+
+	@Override
+	public void afterJob(JobExecution jobExecution) {
+		boolean isSuccess = jobExecution.getStatus().name().equals("COMPLETED");
+
+		sendDiscordMessage(
+				isSuccess ? "배치 작업 성공" : "배치 작업 실패",
+				"배치 작업 후",
+				isSuccess ? 0x57F267 : 0xED4245 // 성공시 녹색, 실패시 빨간색
+		);
+	}
+
+	private void sendDiscordMessage(String title, String description, int color) {
+		try {
+			HttpHeaders headers = new HttpHeaders();
+			headers.setContentType(MediaType.APPLICATION_JSON);
+
+			DiscordMessage message = new DiscordMessage(title, description, color);
+
+			HttpEntity<DiscordMessage> request = new HttpEntity<>(message, headers);
+			RestTemplate restTemplate = new RestTemplate();
+			ResponseEntity<String> response = restTemplate.postForEntity(webHook, request, String.class);
+
+			if (response.getStatusCode() != HttpStatus.NO_CONTENT) {
+				log.error("메시지 전송 중 오류 발생: {}", response.getStatusCode());
+			}
+		} catch (Exception e) {
+			log.error("Discord 메시지 전송 실패", e);
+		}
+	}
+}

--- a/CultureSpot-Batch/src/main/java/com/culturespot/culturespotbatch/alarm/DiscordMessage.java
+++ b/CultureSpot-Batch/src/main/java/com/culturespot/culturespotbatch/alarm/DiscordMessage.java
@@ -1,0 +1,28 @@
+package com.culturespot.culturespotbatch.alarm;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class DiscordMessage {
+
+	private final List<Embed> embeds;
+
+	public DiscordMessage(String title, String description, int color) {
+		this.embeds = List.of(new Embed(title, description, color));
+	}
+
+	@Getter
+	public static class Embed {
+		private final String title;
+		private final String description;
+		private final int color;
+
+		public Embed(String title, String description, int color) {
+			this.title = title;
+			this.description = description;
+			this.color = color;
+		}
+	}
+}

--- a/CultureSpot-Batch/src/main/java/com/culturespot/culturespotbatch/config/BatchWarningConfig.java
+++ b/CultureSpot-Batch/src/main/java/com/culturespot/culturespotbatch/config/BatchWarningConfig.java
@@ -1,0 +1,16 @@
+package com.culturespot.culturespotbatch.config;
+
+import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class BatchWarningConfig {
+
+	// https://github.com/spring-projects/spring-batch/issues/4245
+	// https://github.com/spring-projects/spring-batch/issues/4519
+	@Bean
+	public static BeanDefinitionRegistryPostProcessor jobRegistryPostProcessorRemover() {
+		return registry -> registry.removeBeanDefinition("jobRegistryBeanPostProcessor");
+	}
+}

--- a/CultureSpot-Batch/src/main/java/com/culturespot/culturespotbatch/job/PerformanceBatchJob.java
+++ b/CultureSpot-Batch/src/main/java/com/culturespot/culturespotbatch/job/PerformanceBatchJob.java
@@ -1,0 +1,97 @@
+package com.culturespot.culturespotbatch.job;
+
+import com.culturespot.culturespotapi.api.BatchApiService;
+import com.culturespot.culturespotbatch.alarm.BatchResultToDiscord;
+import com.culturespot.culturespotbatch.processor.PerformanceItemProcessor;
+import com.culturespot.culturespotbatch.reader.PerformanceItemReader;
+import com.culturespot.culturespotbatch.scheduler.CreateDateJobParameter;
+import com.culturespot.culturespotbatch.writer.PerformanceItemWriter;
+import com.culturespot.culturespotdomain.performance.dto.PerformanceDto;
+import com.culturespot.culturespotdomain.performance.entity.Performance;
+import jakarta.persistence.EntityManagerFactory;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.JobScope;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class PerformanceBatchJob {
+
+	private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+	private static final String JOB_NAME = "한눈에보는문화정보조회서비스_분야별공연문화정보목록조회";
+	private static final String BEAN_PREFIX = JOB_NAME + "_";
+
+	private final PlatformTransactionManager platformTransactionManager;
+	private final EntityManagerFactory emf;
+	private final BatchApiService batchApiService;
+	private final JobRepository jobRepository;
+	private final BatchResultToDiscord batchResultToDiscord;
+
+	private int chunkSize;
+	private String jobName;
+
+	@Value("${chunk-size:1000}")
+	public void setChunkSize(int chunkSize) {
+		this.chunkSize = chunkSize;
+	}
+
+	@Bean(BEAN_PREFIX + "jobParameter")
+	@JobScope
+	public CreateDateJobParameter createDateJobParameter() {
+		return new CreateDateJobParameter();
+	}
+
+	@Bean
+	public Job performanceJob() {
+		return new JobBuilder(JOB_NAME, jobRepository)
+				.listener(batchResultToDiscord)	// 디스코드 알림 전송
+				.start(performanceStep())
+				.build();
+	}
+
+	@Bean(BEAN_PREFIX + "_step")
+	@JobScope
+	public Step performanceStep() {
+		LocalDate executeDate = createDateJobParameter().getExecuteDate();
+		String stepName = JOB_NAME + "_" + executeDate.format(DATE_FORMATTER) + "_step";
+
+		return new StepBuilder(stepName, jobRepository)
+				.<PerformanceDto, Performance> chunk(chunkSize, platformTransactionManager)
+				.reader(performanceItemReader())
+				.processor(performanceItemProcessor())
+				.writer(performanceItemWriter())
+				.build();
+	}
+
+	@Bean(BEAN_PREFIX + "_reader")
+	@StepScope
+	public PerformanceItemReader performanceItemReader() {
+		return new PerformanceItemReader(batchApiService);
+	}
+
+	@Bean(BEAN_PREFIX + "_processor")
+	@StepScope
+	public PerformanceItemProcessor performanceItemProcessor() {
+		return new PerformanceItemProcessor();
+	}
+
+	@Bean(BEAN_PREFIX + "_writer")
+	@StepScope
+	public PerformanceItemWriter performanceItemWriter() {
+		return new PerformanceItemWriter(emf);
+	}
+}

--- a/CultureSpot-Batch/src/main/java/com/culturespot/culturespotbatch/job/QuerydslPagingItemReaderJobParameter.java
+++ b/CultureSpot-Batch/src/main/java/com/culturespot/culturespotbatch/job/QuerydslPagingItemReaderJobParameter.java
@@ -1,0 +1,22 @@
+package com.culturespot.culturespotbatch.job;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+@Slf4j
+@Getter
+@NoArgsConstructor
+public class QuerydslPagingItemReaderJobParameter {
+
+	private LocalDate txDate;
+
+	@Value("#{jobParameters[txDate]}")
+	public void setTxDate(String txDate) {
+		this.txDate = LocalDate.parse(txDate, DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+	}
+}

--- a/CultureSpot-Batch/src/main/java/com/culturespot/culturespotbatch/processor/PerformanceItemProcessor.java
+++ b/CultureSpot-Batch/src/main/java/com/culturespot/culturespotbatch/processor/PerformanceItemProcessor.java
@@ -1,0 +1,117 @@
+package com.culturespot.culturespotbatch.processor;
+
+import com.culturespot.culturespotdomain.performance.dto.PerformanceDto;
+import com.culturespot.culturespotdomain.performance.entity.Category;
+import com.culturespot.culturespotdomain.performance.entity.Performance;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.util.StringUtils;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+@Slf4j
+public class PerformanceItemProcessor implements ItemProcessor<PerformanceDto, Performance> {
+
+	private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+	@Override
+	public Performance process(PerformanceDto item) throws Exception {
+		if (item == null) {
+			return null;
+		}
+
+		// Map realm names to Category enum
+		Category category = mapRealmNameToCategory(item.getRealmName());
+
+		// Parse GPS coordinates, defaulting to 0.0 if null or invalid
+		double gpsX = parseCoordinate(item.getGpsX());
+		double gpsY = parseCoordinate(item.getGpsY());
+
+		// Parse sequence number, defaulting to 0 if null or invalid
+		int seq = parseSequence(item.getSeq());
+
+		// Parse dates with default handling
+		LocalDate startDate = parseDate(item.getStartDate());
+		LocalDate endDate = parseDate(item.getEndDate());
+
+		return Performance.builder()
+				.serviceName(item.getServiceName())
+				.seq(seq)
+				.title(item.getTitle())
+				.startDate(startDate)
+				.endDate(endDate)
+				.place(item.getPlace())
+				.category(category)
+				.area(item.getArea())
+				.thumbnail(item.getThumbnail())
+				.gpsX(gpsX)
+				.gpsY(gpsY)
+				.build();
+	}
+
+	private Category mapRealmNameToCategory(String realmName) {
+		switch (realmName) {
+			case "전시":
+				return Category.EXHIBITION;
+			case "연극":
+				return Category.THEATER;
+			case "음악":
+				return Category.MUSIC;
+			case "무용":
+				return Category.DANCING;
+			case "미술":
+				return Category.ART;
+			case "건축":
+				return Category.BUILDING;
+			case "영상":
+				return Category.VIDEO;
+			case "문학":
+				return Category.LITERATURE;
+			case "문화정책":
+				return Category.CULTURAL;
+			case "축제":
+				return Category.FIESTA;
+			default:
+				return Category.ETC;
+		}
+	}
+
+	private double parseCoordinate(String coordinate) {
+		if (!StringUtils.hasText(coordinate)) {
+			return 0.0;
+		}
+		try {
+			return Double.parseDouble(coordinate);
+		} catch (NumberFormatException e) {
+			//log.warn("Invalid coordinate value: {}, defaulting to 0.0", coordinate);
+			return 0.0;
+		}
+	}
+
+	private int parseSequence(String seqStr) {
+		if (!StringUtils.hasText(seqStr)) {
+			//log.warn("Empty sequence, defaulting to 0");
+			return 0;
+		}
+		try {
+			return Integer.parseInt(seqStr);
+		} catch (NumberFormatException e) {
+			//log.warn("Invalid sequence value: {}, defaulting to 0", seqStr);
+			return 0;
+		}
+	}
+
+	private LocalDate parseDate(String dateStr) {
+		if (!StringUtils.hasText(dateStr)) {
+			//log.warn("Empty date, defaulting to current date");
+			return LocalDate.now();
+		}
+		try {
+			return LocalDate.parse(dateStr, DATE_FORMATTER);
+		} catch (Exception e) {
+			//log.warn("Invalid date value: {}, defaulting to current date", dateStr);
+			return LocalDate.now();
+		}
+	}
+}

--- a/CultureSpot-Batch/src/main/java/com/culturespot/culturespotbatch/reader/PerformanceItemReader.java
+++ b/CultureSpot-Batch/src/main/java/com/culturespot/culturespotbatch/reader/PerformanceItemReader.java
@@ -1,0 +1,120 @@
+package com.culturespot.culturespotbatch.reader;
+
+import com.culturespot.culturespotapi.api.BatchApiService;
+import com.culturespot.culturespotdomain.performance.dto.PerformanceDto;
+import com.culturespot.culturespotdomain.performance.dto.PerformanceResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.item.*;
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+
+@Slf4j
+public class PerformanceItemReader implements ItemReader<PerformanceDto>, ItemStream {
+
+	private static final int chunkSize = 1000;
+	private static final String CURRENT_PAGE_KEY = "current.page.exhibition";
+	private static final String END_OF_DATA_KEY = "end.of.data.exhibition";
+
+	private final BatchApiService batchApiService;
+
+	private StepExecution stepExecution;
+	private Queue<PerformanceDto> itemQueue;
+	private int currentPage = 1;
+	private boolean isEndOfData = false;
+
+	public PerformanceItemReader(BatchApiService batchApiService) {
+		this.batchApiService = batchApiService;
+		this.itemQueue = new LinkedList<>();
+	}
+
+	@Override
+	public PerformanceDto read() throws Exception {
+		if (itemQueue.isEmpty() && !isEndOfData) {
+			fetchDataFromApi();
+		}
+
+		return itemQueue.poll();
+	}
+
+	private void fetchDataFromApi() throws Exception {
+		PerformanceResponse response = batchApiService.performanceOpenApiCall(currentPage, chunkSize);
+		processApiResponse(response);
+	}
+
+	private void processApiResponse(PerformanceResponse response) {
+		List<PerformanceResponse.Item> responseItems = response.getBody().getItems().getItemList();
+		List<PerformanceDto> dtoItems = convertToDtoList(responseItems);
+
+		if (!dtoItems.isEmpty()) {
+			itemQueue.addAll(dtoItems);
+		}
+
+		int currentPageNo = response.getBody().getPageNo();
+		int numOfRows = response.getBody().getNumOfRows();
+		int totalCount = response.getBody().getTotalCount();
+
+		boolean isLastPage = (currentPageNo * numOfRows >= totalCount);
+		if (isLastPage) {
+			isEndOfData = true;
+		}
+
+		currentPage++;
+		updateExecutionContext();
+	}
+
+	private List<PerformanceDto> convertToDtoList(List<PerformanceResponse.Item> items) {
+		List<PerformanceDto> dtoList = new ArrayList<>();
+
+		for (PerformanceResponse.Item item : items) {
+			PerformanceDto dto = new PerformanceDto();
+			dto.setSeq(item.getSeq());
+			dto.setTitle(item.getTitle());
+			dto.setServiceName(item.getServiceName());
+			dto.setStartDate(item.getStartDate());
+			dto.setEndDate(item.getEndDate());
+			dto.setPlace(item.getPlace());
+			dto.setRealmName(item.getRealmName());
+			dto.setArea(item.getArea());
+			dto.setThumbnail(item.getThumbnail());
+			dto.setGpsX(item.getGpsX());
+			dto.setGpsY(item.getGpsY());
+
+			dtoList.add(dto);
+		}
+
+		return dtoList;
+	}
+
+	private void updateExecutionContext() {
+		if (stepExecution != null) {
+			ExecutionContext executionContext = stepExecution.getExecutionContext();
+			executionContext.putInt(CURRENT_PAGE_KEY, currentPage);
+		}
+	}
+
+	@Override
+	public void open(ExecutionContext executionContext) throws ItemStreamException {
+		if (executionContext.containsKey(CURRENT_PAGE_KEY)) {
+			currentPage = executionContext.getInt(CURRENT_PAGE_KEY);
+		} else {
+			currentPage = 1;
+		}
+
+		itemQueue = new LinkedList<>();
+	}
+
+	@Override
+	public void update(ExecutionContext executionContext) throws ItemStreamException {
+		executionContext.putInt(CURRENT_PAGE_KEY, currentPage);
+		executionContext.put(END_OF_DATA_KEY, isEndOfData);
+	}
+
+	@Override
+	public void close() throws ItemStreamException {
+		itemQueue.clear();
+	}
+}

--- a/CultureSpot-Batch/src/main/java/com/culturespot/culturespotbatch/reader/QuerydslPagingItemReader.java
+++ b/CultureSpot-Batch/src/main/java/com/culturespot/culturespotbatch/reader/QuerydslPagingItemReader.java
@@ -1,0 +1,101 @@
+package com.culturespot.culturespotbatch.reader;
+
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import org.springframework.batch.item.database.AbstractPagingItemReader;
+import org.springframework.dao.DataAccessResourceFailureException;
+import org.springframework.util.ClassUtils;
+import org.springframework.util.CollectionUtils;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Function;
+
+public class QuerydslPagingItemReader<T> extends AbstractPagingItemReader<T> {
+
+	protected final Map<String, Object> jpaPropertyMap = new HashMap<>();
+	protected EntityManagerFactory entityManagerFactory;
+	protected EntityManager entityManager;
+	protected Function<JPAQueryFactory, JPAQuery<T>> queryFunction;
+	protected boolean transacted = true;    //default value
+
+	protected QuerydslPagingItemReader() {
+		setName(ClassUtils.getShortName(QuerydslPagingItemReader.class));
+	}
+
+	public QuerydslPagingItemReader(EntityManagerFactory emf, int pageSize, Function<JPAQueryFactory, JPAQuery<T>> queryFunction) {
+		this();
+		this.entityManagerFactory = emf;
+		this.queryFunction = queryFunction;
+		setPageSize(pageSize);
+	}
+
+	public void setTransacted(boolean transacted) {
+		this.transacted = transacted;
+	}
+
+	protected void clearIfTransacted() {
+		if (transacted) {
+			entityManager.clear();
+		}
+	}
+
+	protected void initResults() {
+		if (CollectionUtils.isEmpty(results)) {
+			results = new CopyOnWriteArrayList<>();
+		} else {
+			results.clear();
+		}
+	}
+
+	protected JPAQuery<T> createQuery() {
+		JPAQueryFactory queryFactory = new JPAQueryFactory(entityManager);
+		return queryFunction.apply(queryFactory);
+	}
+
+	protected void fetchQuery(JPAQuery<T> query) {
+		if (!transacted) {
+			List<T> queryResult = query.fetch();
+			for (T entity : queryResult) {
+				entityManager.detach(entity);
+				results.add(entity);
+			}
+		} else {
+			results.addAll(query.fetch());
+		}
+	}
+
+	@Override
+	protected void doOpen() throws Exception {
+		super.doOpen();
+
+		EntityManager em = entityManagerFactory.createEntityManager(jpaPropertyMap);
+		if (em == null) {
+			throw new DataAccessResourceFailureException("Unable to obtain an EntityManager");
+		}
+	}
+
+	@Override
+	protected void doClose() throws Exception {
+		entityManager.close();
+		super.doClose();
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	protected void doReadPage() {
+
+		clearIfTransacted();
+
+		JPAQuery<T> query = createQuery()
+				.offset(getPage() * getPageSize())
+				.limit(getPageSize());
+
+		initResults();
+		fetchQuery(query);
+	}
+}

--- a/CultureSpot-Batch/src/main/java/com/culturespot/culturespotbatch/scheduler/CreateDateJobParameter.java
+++ b/CultureSpot-Batch/src/main/java/com/culturespot/culturespotbatch/scheduler/CreateDateJobParameter.java
@@ -1,0 +1,19 @@
+package com.culturespot.culturespotbatch.scheduler;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+@Slf4j
+@Getter
+public class CreateDateJobParameter {
+
+	private final LocalDate executeDate;
+
+	public CreateDateJobParameter() {
+		String today = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+		this.executeDate = LocalDate.parse(today, DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+	}
+}

--- a/CultureSpot-Batch/src/main/java/com/culturespot/culturespotbatch/scheduler/PerformanceJobScheduler.java
+++ b/CultureSpot-Batch/src/main/java/com/culturespot/culturespotbatch/scheduler/PerformanceJobScheduler.java
@@ -1,0 +1,93 @@
+package com.culturespot.culturespotbatch.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.quartz.CronTrigger;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.quartz.CronTriggerFactoryBean;
+import org.springframework.scheduling.quartz.JobDetailFactoryBean;
+import org.springframework.scheduling.quartz.QuartzJobBean;
+import org.springframework.scheduling.quartz.SchedulerFactoryBean;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class PerformanceJobScheduler {
+
+	private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+	private final JobLauncher jobLauncher;
+
+	@Autowired
+	private Job performanceJob;
+
+	@Setter
+	static class PerformanceQuartzJob extends QuartzJobBean {
+
+		private JobLauncher jobLauncher;
+		private Job job;
+
+		@Override
+		protected void executeInternal(JobExecutionContext context) throws JobExecutionException {
+			try {
+				LocalDate now = LocalDate.now();
+				String executeDate = now.format(formatter);
+
+				JobParameters jobParameters = new JobParametersBuilder()
+						.addString("executeDate", executeDate)
+						.addLong("timestamp", System.currentTimeMillis())
+						.toJobParameters();
+
+				jobLauncher.run(job, jobParameters);
+			} catch (Exception e) {
+				throw new JobExecutionException(e);
+			}
+		}
+	}
+
+	@Bean
+	public JobDetailFactoryBean performanceJobDetail() {
+		JobDetailFactoryBean jobDetailFactoryBean = new JobDetailFactoryBean();
+		jobDetailFactoryBean.setJobClass(PerformanceQuartzJob.class);
+		jobDetailFactoryBean.setDurability(true);
+		jobDetailFactoryBean.setName("Performance_Job");
+
+		Map<String, Object> jobDataMap = new HashMap<>();
+		jobDataMap.put("jobLauncher", jobLauncher);
+		jobDataMap.put("job", performanceJob);
+		jobDetailFactoryBean.setJobDataMap(new org.quartz.JobDataMap(jobDataMap));
+		return jobDetailFactoryBean;
+	}
+
+	@Bean
+	public CronTriggerFactoryBean performanceJobTrigger() {
+		CronTriggerFactoryBean triggerFactoryBean = new CronTriggerFactoryBean();
+		triggerFactoryBean.setJobDetail(performanceJobDetail().getObject());
+		triggerFactoryBean.setName("Performance_Job_Trigger");
+
+		triggerFactoryBean.setCronExpression("0/50 * * * * ?");
+		triggerFactoryBean.setMisfireInstruction(CronTrigger.MISFIRE_INSTRUCTION_DO_NOTHING);
+		return triggerFactoryBean;
+	}
+
+	@Bean
+	public SchedulerFactoryBean schedulerFactoryBean() {
+		SchedulerFactoryBean schedulerFactoryBean = new SchedulerFactoryBean();
+		schedulerFactoryBean.setTriggers(performanceJobTrigger().getObject());
+		schedulerFactoryBean.setAutoStartup(true);
+		return schedulerFactoryBean;
+	}
+}

--- a/CultureSpot-Batch/src/main/java/com/culturespot/culturespotbatch/writer/PerformanceItemWriter.java
+++ b/CultureSpot-Batch/src/main/java/com/culturespot/culturespotbatch/writer/PerformanceItemWriter.java
@@ -1,0 +1,28 @@
+package com.culturespot.culturespotbatch.writer;
+
+import com.culturespot.culturespotdomain.performance.entity.Performance;
+import jakarta.persistence.EntityManagerFactory;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.batch.item.database.JpaItemWriter;
+import org.springframework.batch.item.database.builder.JpaItemWriterBuilder;
+
+@Slf4j
+public class PerformanceItemWriter implements ItemWriter<Performance> {
+
+	private final EntityManagerFactory emf;
+	private final JpaItemWriter<Performance> writer;
+
+	public PerformanceItemWriter(EntityManagerFactory emf) {
+		this.emf = emf;
+		this.writer = new JpaItemWriterBuilder<Performance>()
+				.entityManagerFactory(emf)
+				.build();
+	}
+
+	@Override
+	public void write(Chunk<? extends Performance> chunk) throws Exception {
+		writer.write(chunk);
+	}
+}

--- a/CultureSpot-Common/build.gradle
+++ b/CultureSpot-Common/build.gradle
@@ -1,8 +1,9 @@
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    runtimeOnly 'com.mysql:mysql-connector-j'
 }
 
 bootJar.enabled = false
-jar.enabled = true
 
 tasks.register("prepareKotlinBuildScriptModel"){}

--- a/CultureSpot-Common/src/main/java/com/culturespot/culturespotcommon/config/JpaAuditingConfig.java
+++ b/CultureSpot-Common/src/main/java/com/culturespot/culturespotcommon/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.culturespot.culturespotcommon.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/CultureSpot-Common/src/main/java/com/culturespot/culturespotcommon/error/ErrorCode.java
+++ b/CultureSpot-Common/src/main/java/com/culturespot/culturespotcommon/error/ErrorCode.java
@@ -1,0 +1,31 @@
+package com.culturespot.culturespotcommon.error;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
+public enum ErrorCode {
+
+	// Common
+	INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST.value(),"C001", "유효하지 않은 입력값 형식"),
+	METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED.value(), "C002", "허용되지 않는 메서드"),
+	HANDLE_ACCESS_DENIED(HttpStatus.FORBIDDEN.value(), "C005", "접근 권한 불충분");
+
+	// User
+
+	// Batch
+
+	// Community
+
+	private final int status;
+	private final String code;
+	private final String message;
+
+	ErrorCode(final int status, final String code, final String message) {
+		this.status = status;
+		this.code = code;
+		this.message = message;
+	}
+}

--- a/CultureSpot-Common/src/main/java/com/culturespot/culturespotcommon/error/ErrorResponse.java
+++ b/CultureSpot-Common/src/main/java/com/culturespot/culturespotcommon/error/ErrorResponse.java
@@ -1,0 +1,34 @@
+package com.culturespot.culturespotcommon.error;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ErrorResponse {
+
+	private String message;
+	private int status;
+	private List<FieldError> errors;
+	private String code;
+
+	public ErrorResponse(String message, int status, List<FieldError> errors, String code) {
+		this.message = message;
+		this.status = status;
+		this.errors = errors;
+		this.code = code;
+	}
+
+	@Getter
+	@NoArgsConstructor(access = AccessLevel.PROTECTED)
+	static class FieldError {
+		private String field;
+		private String value;
+		private String reason;
+	}
+
+	// @Valid 어노테이션 검증 추가 시 정적 팩토리 메서드 추가 예정
+}

--- a/CultureSpot-Common/src/main/java/com/culturespot/culturespotcommon/exception/CultureSpotException.java
+++ b/CultureSpot-Common/src/main/java/com/culturespot/culturespotcommon/exception/CultureSpotException.java
@@ -1,0 +1,20 @@
+package com.culturespot.culturespotcommon.exception;
+
+import com.culturespot.culturespotcommon.error.ErrorCode;
+import lombok.Getter;
+
+// 비즈니스 최상위 예외 계층
+@Getter
+public class CultureSpotException extends RuntimeException {
+
+	private final ErrorCode errorCode;
+
+	public CultureSpotException(ErrorCode errorCode) {
+		this.errorCode = errorCode;
+	}
+
+	public CultureSpotException(ErrorCode errorCode, String message) {
+		super(message);
+		this.errorCode = errorCode;
+	}
+}

--- a/CultureSpot-Common/src/main/java/com/culturespot/culturespotcommon/global/GlobalExceptionHandler.java
+++ b/CultureSpot-Common/src/main/java/com/culturespot/culturespotcommon/global/GlobalExceptionHandler.java
@@ -1,0 +1,11 @@
+package com.culturespot.culturespotcommon.global;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+	// 각 예외에 맞게끔 추가 예정
+}

--- a/CultureSpot-Domain/build.gradle
+++ b/CultureSpot-Domain/build.gradle
@@ -1,6 +1,23 @@
+bootJar.enabled = false
+
 dependencies {
 
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation project(':CultureSpot-Common')
+
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+    implementation 'org.springframework:spring-oxm'
+    implementation 'jakarta.xml.bind:jakarta.xml.bind-api'
+    implementation 'org.glassfish.jaxb:jaxb-runtime'
+
+    implementation group: 'jakarta.xml.bind', name: 'jakarta.xml.bind-api', version: '4.0.2'
+
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.15.3'
+    implementation 'com.fasterxml:jackson-xml-databind:0.6.2'
 }
 
 tasks.register("prepareKotlinBuildScriptModel"){}

--- a/CultureSpot-Domain/src/main/java/com/culturespot/culturespotdomain/common/BaseEntity.java
+++ b/CultureSpot-Domain/src/main/java/com/culturespot/culturespotdomain/common/BaseEntity.java
@@ -1,0 +1,36 @@
+package com.culturespot.culturespotdomain.common;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public abstract class BaseEntity {
+
+	@CreatedDate
+	@JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+	@JsonSerialize(using = LocalDateTimeSerializer.class)
+	@JsonDeserialize(using = LocalDateTimeDeserializer.class)
+	@Column(name = "created_at")
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	@JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+	@JsonSerialize(using = LocalDateTimeSerializer.class)
+	@JsonDeserialize(using = LocalDateTimeDeserializer.class)
+	@Column(name = "updated_at")
+	private LocalDateTime updatedAt;
+}

--- a/CultureSpot-Domain/src/main/java/com/culturespot/culturespotdomain/performance/dto/PerformanceDto.java
+++ b/CultureSpot-Domain/src/main/java/com/culturespot/culturespotdomain/performance/dto/PerformanceDto.java
@@ -1,0 +1,23 @@
+package com.culturespot.culturespotdomain.performance.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PerformanceDto {
+
+	private String serviceName;
+	private String seq;
+	private String title;
+	private String startDate;
+	private String endDate;
+	private String place;
+	private String realmName;
+	private String area;
+	private String thumbnail;
+	private String gpsX;
+	private String gpsY;
+}

--- a/CultureSpot-Domain/src/main/java/com/culturespot/culturespotdomain/performance/dto/PerformanceResponse.java
+++ b/CultureSpot-Domain/src/main/java/com/culturespot/culturespotdomain/performance/dto/PerformanceResponse.java
@@ -1,0 +1,89 @@
+package com.culturespot.culturespotdomain.performance.dto;
+
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+import lombok.Data;
+import lombok.ToString;
+
+import java.util.List;
+
+@Data
+@ToString
+@JacksonXmlRootElement(localName = "response")
+public class PerformanceResponse {
+
+	@JacksonXmlProperty(localName = "header")
+	private Header header;
+
+	@JacksonXmlProperty(localName = "body")
+	private Body body;
+
+	@Data
+	public static class Header {
+
+		@JacksonXmlProperty(localName = "reseultCode") 	// XML에는 "reseultCode"로 오타가 있음에 주의
+		private String resultCode;
+
+		@JacksonXmlProperty(localName = "resultMsg")
+		private String resultMsg;
+	}
+
+	@Data
+	public static class Body {
+		@JacksonXmlProperty(localName = "totalCount")
+		private int totalCount;
+
+		@JacksonXmlProperty(localName = "PageNo")
+		private int pageNo;
+
+		@JacksonXmlProperty(localName = "numOfrows")
+		private int numOfRows;
+
+		@JacksonXmlProperty(localName = "items")
+		private Items items;
+	}
+
+	@Data
+	public static class Items {
+		@JacksonXmlElementWrapper(useWrapping = false)
+		@JacksonXmlProperty(localName = "item")
+		private List<Item> itemList;
+	}
+
+	@Data
+	public static class Item {
+		@JacksonXmlProperty(localName = "serviceName")
+		private String serviceName;
+
+		@JacksonXmlProperty(localName = "seq")
+		private String seq;
+
+		@JacksonXmlProperty(localName = "title")
+		private String title;
+
+		@JacksonXmlProperty(localName = "startDate")
+		private String startDate;
+
+		@JacksonXmlProperty(localName = "endDate")
+		private String endDate;
+
+		@JacksonXmlProperty(localName = "place")
+		private String place;
+
+		@JacksonXmlProperty(localName = "realmName")
+		private String realmName;
+
+		@JacksonXmlProperty(localName = "area")
+		private String area;
+
+		@JacksonXmlProperty(localName = "thumbnail")
+		private String thumbnail;
+
+		@JacksonXmlProperty(localName = "gpsX")
+		private String gpsX;
+
+		@JacksonXmlProperty(localName = "gpsY")
+		private String gpsY;
+	}
+}

--- a/CultureSpot-Domain/src/main/java/com/culturespot/culturespotdomain/performance/entity/Category.java
+++ b/CultureSpot-Domain/src/main/java/com/culturespot/culturespotdomain/performance/entity/Category.java
@@ -1,0 +1,25 @@
+package com.culturespot.culturespotdomain.performance.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum Category {
+
+	EXHIBITION("전시"),
+	THEATER("연극"),
+	MUSIC("음악"),
+	DANCING("무용"),
+	ART("미술"),
+	BUILDING("건축"),
+	VIDEO("영상"),
+	LITERATURE("문학"),
+	CULTURAL("문화정책"),
+	FIESTA("축제"),
+	ETC("기타");
+
+	private final String description;
+
+	Category(String description) {
+		this.description = description;
+	}
+}

--- a/CultureSpot-Domain/src/main/java/com/culturespot/culturespotdomain/performance/entity/Performance.java
+++ b/CultureSpot-Domain/src/main/java/com/culturespot/culturespotdomain/performance/entity/Performance.java
@@ -1,0 +1,69 @@
+package com.culturespot.culturespotdomain.performance.entity;
+
+import com.culturespot.culturespotdomain.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Performance extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "performance_id")
+	private Long id;
+
+	@Column(name = "service_name")
+	private String serviceName;	// 서비스명
+
+	@Column(name = "seq")
+	private int seq;			// 일련번호
+
+	@Column(name = "title")
+	private String title;		// 제목
+
+	@Column(name = "startDate")
+	private LocalDate startDate;	// 시작일자
+
+	@Column(name = "endDate")
+	private LocalDate endDate;		// 마감일자
+
+	@Column(name = "place")
+	private String place;		// 장소
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "category")
+	private Category category;	// 분류명
+
+	@Column(name = "area")
+	private String area;		// 지역
+
+	@Column(name = "thumbnail")
+	private String thumbnail;	// 썸네일
+
+	@Column(name = "gpsX")
+	private double gpsX;		// GPS-X좌표
+
+	@Column(name = "gpsY")
+	private double gpsY;		// GPS=Y좌표
+
+	@Builder
+	private Performance(String serviceName, int seq, String title, LocalDate startDate, LocalDate endDate,
+						String place, Category category, String area, String thumbnail, double gpsX, double gpsY) {
+		this.serviceName = serviceName;
+		this.seq = seq;
+		this.title = title;
+		this.startDate = startDate;
+		this.endDate = endDate;
+		this.place = place;
+		this.category = category;
+		this.area = area;
+		this.thumbnail = thumbnail;
+		this.gpsX = gpsX;
+		this.gpsY = gpsY;
+	}
+}

--- a/CultureSpot-Domain/src/main/java/com/culturespot/culturespotdomain/performance/repository/PerformanceRepository.java
+++ b/CultureSpot-Domain/src/main/java/com/culturespot/culturespotdomain/performance/repository/PerformanceRepository.java
@@ -1,0 +1,7 @@
+package com.culturespot.culturespotdomain.performance.repository;
+
+import com.culturespot.culturespotdomain.performance.entity.Performance;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PerformanceRepository extends JpaRepository<Performance, Long> {
+}

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'io.spring.dependency-management' version '1.1.7'
 }
 
-bootJar.enabled = false
+bootJar.enabled = true
 
 subprojects {
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+services:
+  mysql:
+    container_name: mysql-container
+    image: mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: culturespot
+      MYSQL_DATABASE: culturespot
+    ports:
+      - '3306:3306'
+    volumes:
+      - ./mysql_data:/var/lib/mysql
+    healthcheck:
+      test: [ "CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-p$$MYSQL_ROOT_PASSWORD" ]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped


### PR DESCRIPTION
## 이슈 번호, 혹은 추가한 기능에 대해 설명해주세요.

* #11 

## 작업 상세 내용

- [ ] [한국문화정보원_한눈에보는문화정보조회서비스] 분야/기간/지역별 정보 조회 배치 개발 내역입니다.
- [ ] 데이터의 수집은 1주일 분량으로 제한했으며, 배치 실행 주기는 테스트를 위해 짧게 설정된 상황입니다.

## 기타 내용

- Docker & Jenkins 관리는 차후 백엔드 서버 배포 일정에 맞춰 진행할 예정
- 배치 주기는 추후 서비스 과정에서 조정될 수 있습니다.
- @chopinoff 님 의견에 따라서 일단 Jira를 최대한 활용할 수 있는 방향으로 처리해드렸습니다. 결정하시고 확정된 방안 전달 부탁드립니다.