### PR TITLE
[CUL-158] jpa ddl-auto 옵션 수정

### DIFF
--- a/CultureSpot-Domain/src/main/resources/application-test.yml
+++ b/CultureSpot-Domain/src/main/resources/application-test.yml
@@ -6,4 +6,4 @@ spring:
     password:
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: update

--- a/CultureSpot-Domain/src/main/resources/application.yml
+++ b/CultureSpot-Domain/src/main/resources/application.yml
@@ -20,7 +20,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: update
     show-sql: true
     properties:
       hibernate.format_sql: true


### PR DESCRIPTION
application.yml 파일의 jpa 옵션 중 하나인 ddl-auto 값을 create-drop에서 update로 변경해보았습니다.
기본 설정이라 dev로 병합하도록 했습니다.
자세한 이유는 다음 링크에 작성해두었고, 검토해주시면 감사드리겠습니다!
[[JPA Error] error executing ddl - alter table drop foreign key](https://velog.io/@otyvs1109/JPA-Error-error-executing-ddl-alter-table-drop-foreign-key)