### PR TITLE
[CUL-157] 생성 및 수정일 컬럼의 상속화

### DIFF
--- a/CultureSpot-Domain/src/main/java/com/culturespot/culturespotdomain/core/comment/entity/Comment.java
+++ b/CultureSpot-Domain/src/main/java/com/culturespot/culturespotdomain/core/comment/entity/Comment.java
@@ -1,22 +1,18 @@
 package com.culturespot.culturespotdomain.core.comment.entity;
 
+import com.culturespot.culturespotdomain.core.global.entity.BaseEntity;
 import com.culturespot.culturespotdomain.core.post.entity.Post;
 import com.culturespot.culturespotdomain.core.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
-import java.time.LocalDateTime;
 
 @Getter
 @Entity
-@Table(name = "comments")@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@EntityListeners(AuditingEntityListener.class)
-public class Comment {
+@Table(name = "comments")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Comment extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long Id;
@@ -31,12 +27,4 @@ public class Comment {
 
     @Column
     private String content;
-
-    @CreatedDate
-    @Column(updatable = false, nullable = false)  // 생성일 수정 불가
-    private LocalDateTime createdAt;
-
-    @LastModifiedDate
-    @Column(nullable = false)
-    private LocalDateTime modifiedAt;
 }

--- a/CultureSpot-Domain/src/main/java/com/culturespot/culturespotdomain/core/global/entity/BaseEntity.java
+++ b/CultureSpot-Domain/src/main/java/com/culturespot/culturespotdomain/core/global/entity/BaseEntity.java
@@ -1,0 +1,32 @@
+package com.culturespot.culturespotdomain.core.global.entity;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity {
+
+    @CreatedDate
+    @Column(updatable = false, nullable = false)  // 생성일 수정 불가
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    private LocalDateTime modifiedAt;
+}

--- a/CultureSpot-Domain/src/main/java/com/culturespot/culturespotdomain/core/post/entity/Post.java
+++ b/CultureSpot-Domain/src/main/java/com/culturespot/culturespotdomain/core/post/entity/Post.java
@@ -1,14 +1,10 @@
 package com.culturespot.culturespotdomain.core.post.entity;
 
+import com.culturespot.culturespotdomain.core.global.entity.BaseEntity;
 import com.culturespot.culturespotdomain.core.image.entity.Image;
 import com.culturespot.culturespotdomain.core.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -16,8 +12,7 @@ import java.util.List;
 @Entity
 @Table(name = "posts")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@EntityListeners(AuditingEntityListener.class)
-public class Post {
+public class Post extends BaseEntity {
     // ************************ column ************************ //
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -42,13 +37,6 @@ public class Post {
     @Column(nullable = false)
     private Long viewCount = 0L;
 
-    @CreatedDate
-    @Column(updatable = false, nullable = false)  // 생성일 수정 불가
-    private LocalDateTime createdAt;
-
-    @LastModifiedDate
-    @Column(nullable = false)
-    private LocalDateTime modifiedAt;
     // ************************ column ************************ //
 
     @Builder

--- a/CultureSpot-Domain/src/main/java/com/culturespot/culturespotdomain/core/user/entity/User.java
+++ b/CultureSpot-Domain/src/main/java/com/culturespot/culturespotdomain/core/user/entity/User.java
@@ -1,24 +1,19 @@
 package com.culturespot.culturespotdomain.core.user.entity;
 
+import com.culturespot.culturespotdomain.core.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
-import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.Set;
 
 @Entity
 @Table(name = "users")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@EntityListeners(AuditingEntityListener.class)
 @Getter
-public class User {
+public class User extends BaseEntity {
     // ************************ column ************************ //
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -36,14 +31,6 @@ public class User {
     @Enumerated(EnumType.STRING)
     @Column(nullable = true)
     private SocialLoginType authType;
-
-    @CreatedDate
-    @Column(updatable = false, nullable = false)
-    private LocalDateTime createdAt;
-
-    @LastModifiedDate
-    @Column(nullable = false)
-    private LocalDateTime modifiedAt;
     // ************************ column ************************ //
 
     @OneToMany(mappedBy = "user", fetch = FetchType.EAGER, cascade = CascadeType.ALL)


### PR DESCRIPTION
JPA의 AuditingEntityListener 를 이용하여 생성일과 수정일 컬럼을 자동으로 관리하는 BaseEntity를 작성하였습니다.
이후 관련 컬럼이 포함된 3개의 엔티티에서 해당 필드를 삭제하였고, BaseEntity를 상속받도록 하여 코드의 중복을 없앴습니다.
늦은 시간이라 임의로 진행한 점 죄송합니다😅 관련하여 의견 주시면 감사드리겠습니다!