### PR TITLE
[CUL-85] 카카오 소셜 로그인 구현

### DIFF
--- a/CultureSpot-Domain/src/main/java/com/culturespot/culturespotdomain/core/global/exception/AuthExceptionCode.java
+++ b/CultureSpot-Domain/src/main/java/com/culturespot/culturespotdomain/core/global/exception/AuthExceptionCode.java
@@ -9,20 +9,27 @@ public enum AuthExceptionCode {
     TOKEN(1000),
     UNKNOWN_ERROR(TOKEN.code + 1, "알 수 없는 오류가 발생했습니다. 관리자에게 문의하세요."),
     // Access token
-    EXPIRED_ACCESS_TOKEN(TOKEN.code + 2, "JWT가 만료되었습니다."),
-    MALFORMED_ACCESS_TOKEN(TOKEN.code + 3, "JWT 형식이 잘못되었습니다."),
-    SIGNATURE_ACCESS_TOKEN(TOKEN.code + 4, "JWT 서명이 유효하지 않습니다."),
+    EXPIRED_ACCESS_TOKEN(TOKEN.code + 50, "JWT가 만료되었습니다."),
+    MALFORMED_ACCESS_TOKEN(TOKEN.code + 51, "JWT 형식이 잘못되었습니다."),
+    SIGNATURE_ACCESS_TOKEN(TOKEN.code + 52, "JWT 서명이 유효하지 않습니다."),
     // Refresh token
-    EXPIRED_REFRESH_TOKEN(TOKEN.code + 2, "Refresh token이 만료되었습니다. 다시 로그인해주세요"),
-    MALFORMED_REFRESH_TOKEN(TOKEN.code + 3, "Refresh token 형식이 잘못되었습니다."),
-    SIGNATURE_REFRESH_TOKEN(TOKEN.code + 4, "Refresh token 서명이 유효하지 않습니다."),
+    EXPIRED_REFRESH_TOKEN(TOKEN.code + 80, "Refresh token이 만료되었습니다. 다시 로그인해주세요"),
+    MALFORMED_REFRESH_TOKEN(TOKEN.code + 81, "Refresh token 형식이 잘못되었습니다."),
+    SIGNATURE_REFRESH_TOKEN(TOKEN.code + 82, "Refresh token 서명이 유효하지 않습니다."),
 
     ROLE(900),
 
     USER(800),
     USER_NOT_FOUND(USER.code + 1, "사용자를 찾을 수 없습니다."),
     UNAUTHENTICATED_USER(USER.code + 2, "인증된 사용자만 접근 가능합니다."),
-    INVALID_AUTHENTICATION(USER.code + 3, "잘못된 인증 정보입니다.");
+
+    AUTHENTICATION(700),
+    CANCELLED_AUTHENTICATION(AUTHENTICATION.code + 1, "사용자가 회원가입 또는 로그인을 취소했습니다."),
+    INVALID_AUTHENTICATION(USER.code + 2, "잘못된 인증 정보입니다."),
+
+
+    LOGIN(600),
+    UNSUPPORTED_LOGIN_METHOD(LOGIN.code + 1, "지원하지 않는 로그인 방식입니다.");
 
     private final int code;
     private final String message;

--- a/CultureSpot-Domain/src/main/java/com/culturespot/culturespotdomain/core/global/exception/ExceptionStatusMapper.java
+++ b/CultureSpot-Domain/src/main/java/com/culturespot/culturespotdomain/core/global/exception/ExceptionStatusMapper.java
@@ -19,10 +19,16 @@ public class ExceptionStatusMapper {
         AUTH_STATUS_MAP.put(AuthExceptionCode.MALFORMED_ACCESS_TOKEN.getCode(), HttpStatus.BAD_REQUEST); //🔥400
         AUTH_STATUS_MAP.put(AuthExceptionCode.SIGNATURE_ACCESS_TOKEN.getCode(), HttpStatus.UNAUTHORIZED); //🔥401
         // refresh-token
+        AUTH_STATUS_MAP.put(AuthExceptionCode.EXPIRED_REFRESH_TOKEN.getCode(), HttpStatus.UNAUTHORIZED); //🔥401
+        AUTH_STATUS_MAP.put(AuthExceptionCode.MALFORMED_REFRESH_TOKEN.getCode(), HttpStatus.BAD_REQUEST); //🔥400
+        AUTH_STATUS_MAP.put(AuthExceptionCode.SIGNATURE_REFRESH_TOKEN.getCode(), HttpStatus.UNAUTHORIZED); //🔥401
 
         // USER
         AUTH_STATUS_MAP.put(AuthExceptionCode.USER_NOT_FOUND.getCode(), HttpStatus.NOT_FOUND); //🔥404
         AUTH_STATUS_MAP.put(AuthExceptionCode.UNAUTHENTICATED_USER.getCode(), HttpStatus.FORBIDDEN); //🔥403
+
+        // AUTHENTICATION
+        AUTH_STATUS_MAP.put(AuthExceptionCode.CANCELLED_AUTHENTICATION.getCode(), HttpStatus.NO_CONTENT); //🔥204
         AUTH_STATUS_MAP.put(AuthExceptionCode.INVALID_AUTHENTICATION.getCode(), HttpStatus.UNAUTHORIZED); //🔥401
 
         /* ✅ DomainException 상태 코드 매핑 */

--- a/CultureSpot-Domain/src/main/java/com/culturespot/culturespotdomain/core/post/service/PostServiceImpl.java
+++ b/CultureSpot-Domain/src/main/java/com/culturespot/culturespotdomain/core/post/service/PostServiceImpl.java
@@ -2,15 +2,23 @@ package com.culturespot.culturespotdomain.core.post.service;
 
 import com.culturespot.culturespotdomain.core.global.exception.DomainException;
 import com.culturespot.culturespotdomain.core.global.exception.DomainExceptionCode;
+import com.culturespot.culturespotdomain.core.image.entity.Image;
 import com.culturespot.culturespotdomain.core.image.service.ImageService;
+import com.culturespot.culturespotdomain.core.image.dto.ImageDetailRequest;
 import com.culturespot.culturespotdomain.core.post.entity.Post;
-import com.culturespot.culturespotdomain.core.post.dto.PostModifyCommand;
 import com.culturespot.culturespotdomain.core.post.repository.PostRepository;
+import com.culturespot.culturespotdomain.core.post.dto.PostCreateRequest;
+import com.culturespot.culturespotdomain.core.post.dto.PostDetails;
+import com.culturespot.culturespotdomain.core.post.dto.PostModifyRequest;
+import com.culturespot.culturespotdomain.core.post.dto.PostSingleResponse;
 import com.culturespot.culturespotdomain.core.user.entity.User;
 import com.culturespot.culturespotdomain.core.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -21,34 +29,35 @@ public class PostServiceImpl implements PostService {
 
     @Override
     @Transactional(readOnly = true)
-    public Post getPost(Long postId) {
-        return findPostOrThrow(postId);
+    public PostSingleResponse getPost(Long postId) {
+        Post findPost = findPostOrThrow(postId);
+        return PostSingleResponse.from(findPost);
     }
 
     @Override
     @Transactional
-    public void createPost(User user, Post post) {
-//        User findUser = userService.findUserOrThrow(user.getEmail());
+    public void createPost(User user, PostCreateRequest request) {
+        User findUser = userService.findUserOrThrow(user.getEmail());
 
-//        PostDetails postDetails = post;
-//        Post post = createEmptyPost(findUser, postDetails);
-//
-//        List<Image> images = imageService.createImage(post, request.images());
-//        post.getImages().addAll(images);
-//
-//        postRepository.save(post);
+        PostDetails postDetails = request.post();
+        Post post = createEmptyPost(findUser, postDetails);
+
+        List<Image> images = imageService.createImage(post, request.images());
+        post.getImages().addAll(images);
+
+        postRepository.save(post);
     }
 
     @Override
     @Transactional
-    public void modifyPost(User user, Long postId, PostModifyCommand command) {
-//        Post currentPost = findPostOrThrow(postId);
-//
-//        PostValidator.validateEditPermission(user.getId(), currentPost.getId());
-//
-//        Post updatePost = modifyPostDetails(currentPost, request);
-//
-//        postRepository.save(updatePost);
+    public void modifyPost(User user, Long postId, PostModifyRequest request) {
+        Post currentPost = findPostOrThrow(postId);
+
+        PostValidator.validateEditPermission(user.getId(), currentPost.getPostId());
+
+        Post updatePost = modifyPostDetails(currentPost, request);
+
+        postRepository.save(updatePost);
     }
 
     @Override
@@ -62,43 +71,43 @@ public class PostServiceImpl implements PostService {
         imageService.deleteImages(postId);
     }
 
-//    public Post createEmptyPost(User user, PostDetails postDetails) {
-//        return Post.builder()
-//                .user(user)
-//                .title(postDetails.title())
-//                .content(postDetails.content())
-//                .images(new ArrayList<>())
-//                .build();
-//    }
+    public Post createEmptyPost(User user, PostDetails request) {
+        return Post.builder()
+                .user(user)
+                .title(request.title())
+                .content(request.content())
+                .images(new ArrayList<>())
+                .build();
+    }
 
     public Post findPostOrThrow(Long postId) {
         return postRepository.findById(postId)
                 .orElseThrow(() -> new DomainException(DomainExceptionCode.POST_NOT_FOUND));
     }
 
-//    public Post modifyPostDetails(Post post, PostModifyRequest request) {
-//        PostDetails postDetails = request.postDetails();
-//        List<ImageDetailRequest> deleteImages = request.deleteImage();
-//        List<Long> deleteImagesId = deleteImages.stream()
-//                .map(ImageDetailRequest::imageId)
-//                .toList();
-//
-//        if (postDetails.title() != null) {
-//            post.setTitle(postDetails.title());
-//        }
-//
-//        if (postDetails.content() != null) {
-//            post.setContent(postDetails.content());
-//        }
-//
-//        if (request.images() != null && !request.images().isEmpty()) {
-//            post.setImages(imageService.createImage(post, request.images()));
-//        }
-//
-//        if (!deleteImages.isEmpty()) {
-//            imageService.deleteImages(deleteImagesId);
-//        }
-//
-//        return post;
-//    }
+    public Post modifyPostDetails(Post post, PostModifyRequest request) {
+        PostDetails postDetails = request.postDetails();
+        List<ImageDetailRequest> deleteImages = request.deleteImage();
+        List<Long> deleteImagesId = deleteImages.stream()
+                .map(ImageDetailRequest::imageId)
+                .toList();
+
+        if (postDetails.title() != null) {
+            post.setTitle(postDetails.title());
+        }
+
+        if (postDetails.content() != null) {
+            post.setContent(postDetails.content());
+        }
+
+        if (request.images() != null && !request.images().isEmpty()) {
+            post.setImages(imageService.createImage(post, request.images()));
+        }
+
+        if (!deleteImages.isEmpty()) {
+            imageService.deleteImages(deleteImagesId);
+        }
+
+        return post;
+    }
 }

--- a/CultureSpot-Domain/src/main/java/com/culturespot/culturespotdomain/core/post/service/PostServiceImpl.java
+++ b/CultureSpot-Domain/src/main/java/com/culturespot/culturespotdomain/core/post/service/PostServiceImpl.java
@@ -2,15 +2,10 @@ package com.culturespot.culturespotdomain.core.post.service;
 
 import com.culturespot.culturespotdomain.core.global.exception.DomainException;
 import com.culturespot.culturespotdomain.core.global.exception.DomainExceptionCode;
-import com.culturespot.culturespotdomain.core.image.entity.Image;
 import com.culturespot.culturespotdomain.core.image.service.ImageService;
-import com.culturespot.culturespotdomain.core.image.dto.ImageDetailRequest;
 import com.culturespot.culturespotdomain.core.post.entity.Post;
+import com.culturespot.culturespotdomain.core.post.dto.PostModifyCommand;
 import com.culturespot.culturespotdomain.core.post.repository.PostRepository;
-import com.culturespot.culturespotdomain.core.post.dto.PostCreateRequest;
-import com.culturespot.culturespotdomain.core.post.dto.PostDetails;
-import com.culturespot.culturespotdomain.core.post.dto.PostModifyRequest;
-import com.culturespot.culturespotdomain.core.post.dto.PostSingleResponse;
 import com.culturespot.culturespotdomain.core.user.entity.User;
 import com.culturespot.culturespotdomain.core.user.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -29,35 +24,34 @@ public class PostServiceImpl implements PostService {
 
     @Override
     @Transactional(readOnly = true)
-    public PostSingleResponse getPost(Long postId) {
-        Post findPost = findPostOrThrow(postId);
-        return PostSingleResponse.from(findPost);
+    public Post getPost(Long postId) {
+        return findPostOrThrow(postId);
     }
 
     @Override
     @Transactional
-    public void createPost(User user, PostCreateRequest request) {
-        User findUser = userService.findUserOrThrow(user.getEmail());
+    public void createPost(User user, Post post) {
+//        User findUser = userService.findUserOrThrow(user.getEmail());
 
-        PostDetails postDetails = request.post();
-        Post post = createEmptyPost(findUser, postDetails);
-
-        List<Image> images = imageService.createImage(post, request.images());
-        post.getImages().addAll(images);
-
-        postRepository.save(post);
+//        PostDetails postDetails = post;
+//        Post post = createEmptyPost(findUser, postDetails);
+//
+//        List<Image> images = imageService.createImage(post, request.images());
+//        post.getImages().addAll(images);
+//
+//        postRepository.save(post);
     }
 
     @Override
     @Transactional
-    public void modifyPost(User user, Long postId, PostModifyRequest request) {
-        Post currentPost = findPostOrThrow(postId);
-
-        PostValidator.validateEditPermission(user.getId(), currentPost.getPostId());
-
-        Post updatePost = modifyPostDetails(currentPost, request);
-
-        postRepository.save(updatePost);
+    public void modifyPost(User user, Long postId, PostModifyCommand command) {
+//        Post currentPost = findPostOrThrow(postId);
+//
+//        PostValidator.validateEditPermission(user.getId(), currentPost.getId());
+//
+//        Post updatePost = modifyPostDetails(currentPost, request);
+//
+//        postRepository.save(updatePost);
     }
 
     @Override
@@ -71,43 +65,43 @@ public class PostServiceImpl implements PostService {
         imageService.deleteImages(postId);
     }
 
-    public Post createEmptyPost(User user, PostDetails request) {
-        return Post.builder()
-                .user(user)
-                .title(request.title())
-                .content(request.content())
-                .images(new ArrayList<>())
-                .build();
-    }
+//    public Post createEmptyPost(User user, PostDetails postDetails) {
+//        return Post.builder()
+//                .user(user)
+//                .title(postDetails.title())
+//                .content(postDetails.content())
+//                .images(new ArrayList<>())
+//                .build();
+//    }
 
     public Post findPostOrThrow(Long postId) {
         return postRepository.findById(postId)
                 .orElseThrow(() -> new DomainException(DomainExceptionCode.POST_NOT_FOUND));
     }
 
-    public Post modifyPostDetails(Post post, PostModifyRequest request) {
-        PostDetails postDetails = request.postDetails();
-        List<ImageDetailRequest> deleteImages = request.deleteImage();
-        List<Long> deleteImagesId = deleteImages.stream()
-                .map(ImageDetailRequest::imageId)
-                .toList();
-
-        if (postDetails.title() != null) {
-            post.setTitle(postDetails.title());
-        }
-
-        if (postDetails.content() != null) {
-            post.setContent(postDetails.content());
-        }
-
-        if (request.images() != null && !request.images().isEmpty()) {
-            post.setImages(imageService.createImage(post, request.images()));
-        }
-
-        if (!deleteImages.isEmpty()) {
-            imageService.deleteImages(deleteImagesId);
-        }
-
-        return post;
-    }
+//    public Post modifyPostDetails(Post post, PostModifyRequest request) {
+//        PostDetails postDetails = request.postDetails();
+//        List<ImageDetailRequest> deleteImages = request.deleteImage();
+//        List<Long> deleteImagesId = deleteImages.stream()
+//                .map(ImageDetailRequest::imageId)
+//                .toList();
+//
+//        if (postDetails.title() != null) {
+//            post.setTitle(postDetails.title());
+//        }
+//
+//        if (postDetails.content() != null) {
+//            post.setContent(postDetails.content());
+//        }
+//
+//        if (request.images() != null && !request.images().isEmpty()) {
+//            post.setImages(imageService.createImage(post, request.images()));
+//        }
+//
+//        if (!deleteImages.isEmpty()) {
+//            imageService.deleteImages(deleteImagesId);
+//        }
+//
+//        return post;
+//    }
 }

--- a/CultureSpot-Domain/src/main/java/com/culturespot/culturespotdomain/core/user/entity/User.java
+++ b/CultureSpot-Domain/src/main/java/com/culturespot/culturespotdomain/core/user/entity/User.java
@@ -28,6 +28,9 @@ public class User extends BaseEntity {
     @Column(nullable = false, unique = true)
     private String nickname;
 
+    @Column(name="profile_code", nullable = false)
+    private int profileCode;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = true)
     private SocialLoginType authType;
@@ -42,13 +45,15 @@ public class User extends BaseEntity {
             String nickname,
             SocialLoginType authType,
             Set<UserRole> roles,
-            String password
+            String password,
+            int profileCode
     ){
         this.email = email;
         this.nickname = nickname;
         this.authType = authType;
         this.roles = roles;
         this.password = password;
+        this.profileCode = profileCode;
     }
 
     public void addRole(UserRole userRole) {

--- a/CultureSpot-Domain/src/main/java/com/culturespot/culturespotdomain/core/user/entity/User.java
+++ b/CultureSpot-Domain/src/main/java/com/culturespot/culturespotdomain/core/user/entity/User.java
@@ -34,11 +34,11 @@ public class User extends BaseEntity {
     private int profileCode;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = true)
+    @Column(nullable = false)
     private SocialLoginType authType;
 
     @Column(name="last_login_at", nullable = false)
-    private LocalDateTime lastLoginAt = LocalDateTime.now();
+    private LocalDateTime lastLoginAt;
     // ************************ column ************************ //
 
     @OneToMany(mappedBy = "user", fetch = FetchType.EAGER, cascade = CascadeType.ALL)
@@ -51,7 +51,8 @@ public class User extends BaseEntity {
             SocialLoginType authType,
             Set<UserRole> roles,
             String password,
-            int profileCode
+            int profileCode,
+            LocalDateTime lastLoginAt
     ){
         this.email = email;
         this.nickname = nickname;
@@ -59,6 +60,7 @@ public class User extends BaseEntity {
         this.roles = roles;
         this.password = password;
         this.profileCode = profileCode;
+        this.lastLoginAt = lastLoginAt;
     }
 
     public void addRole(UserRole userRole) {

--- a/CultureSpot-Domain/src/main/java/com/culturespot/culturespotdomain/core/user/entity/User.java
+++ b/CultureSpot-Domain/src/main/java/com/culturespot/culturespotdomain/core/user/entity/User.java
@@ -6,6 +6,8 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -34,6 +36,9 @@ public class User extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(nullable = true)
     private SocialLoginType authType;
+
+    @Column(name="last_login_at", nullable = false)
+    private LocalDateTime lastLoginAt = LocalDateTime.now();
     // ************************ column ************************ //
 
     @OneToMany(mappedBy = "user", fetch = FetchType.EAGER, cascade = CascadeType.ALL)

--- a/CultureSpot-Domain/src/main/java/com/culturespot/culturespotdomain/core/user/repository/UserRepository.java
+++ b/CultureSpot-Domain/src/main/java/com/culturespot/culturespotdomain/core/user/repository/UserRepository.java
@@ -2,9 +2,17 @@ package com.culturespot.culturespotdomain.core.user.repository;
 
 import com.culturespot.culturespotdomain.core.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
+
+    @Modifying
+    @Query("UPDATE User u SET u.lastLoginAt = :lastLoginAt WHERE u.id = :userId")
+    void updateLastLoginAt(@Param("userId") Long userId, @Param("lastLoginAt") LocalDateTime lastLoginAt);
 }

--- a/CultureSpot-Domain/src/main/java/com/culturespot/culturespotdomain/core/user/service/UserService.java
+++ b/CultureSpot-Domain/src/main/java/com/culturespot/culturespotdomain/core/user/service/UserService.java
@@ -18,27 +18,16 @@ public interface UserService{
      * @return 사용자가 가진 권한 이름의 집합 (예: "USER", "ADMIN")
      * */
     Set<String> getRoleNames(User user);
-
     /**
      * 주어진 이메일에 해당하는 사용자를 조회
      * <p>
      * 사용자가 존재하면 해당 {@link User} 객체를 반환하고, 존재하지 않으면 {@link AuthException}을 발생시킵니다.
      * </p>
      *
-     * @param email 사용자의 이메일 주소
-     * @return 이메일에 해당하는 {@link User} 객체 반환
      * @throws {@link AuthException} 사용자가 존재하지 않는다면 {@link AuthExceptionCode#USER_NOT_FOUND} 예외를 발생
      */
     User findUserOrThrow(String email);
-
-    /**
-     * 사용자가 존재하지 않으면 새로 생성하고 저장하는 메서드
-     *
-     * @param email 사용자의 이메일
-     * @param authType 소셜 로그인 타입 (예: {@link SocialLoginType#GOOGLE}, {@link SocialLoginType#KAKAO})
-     * @return 생성되거나 기존에 존재하던 {@link User} 객체
-     */
     User createUserIfNotExists(String email, SocialLoginType authType);
-
-    public void updateLastLoginAt(User user);
+    User createUser(String email, SocialLoginType authType);
+    void updateLastLoginAt(User user);
 }

--- a/CultureSpot-Domain/src/main/java/com/culturespot/culturespotdomain/core/user/service/UserService.java
+++ b/CultureSpot-Domain/src/main/java/com/culturespot/culturespotdomain/core/user/service/UserService.java
@@ -1,12 +1,42 @@
 package com.culturespot.culturespotdomain.core.user.service;
 
+import com.culturespot.culturespotdomain.core.global.exception.AuthException;
+import com.culturespot.culturespotdomain.core.global.exception.AuthExceptionCode;
 import com.culturespot.culturespotdomain.core.user.entity.SocialLoginType;
 import com.culturespot.culturespotdomain.core.user.entity.User;
 
 import java.util.Set;
 
 public interface UserService{
+    /**
+     *  사용자가 갖고 있는 권한 조회
+     * <p>
+     * 권한 이름은 {@link com.culturespot.culturespotdomain.core.role.entity.UserRoleType} enum의 name() 값을 기준으로 하며,
+     * 중복 없이 {@link Set} 형태로 반환됩니다.
+     * </p>
+     * @param user 사용자 정보를 담고 있는 {@link User} 객체
+     * @return 사용자가 가진 권한 이름의 집합 (예: "USER", "ADMIN")
+     * */
     Set<String> getRoleNames(User user);
-    User findUserOrThrow(String username);
+
+    /**
+     * 주어진 이메일에 해당하는 사용자를 조회
+     * <p>
+     * 사용자가 존재하면 해당 {@link User} 객체를 반환하고, 존재하지 않으면 {@link AuthException}을 발생시킵니다.
+     * </p>
+     *
+     * @param email 사용자의 이메일 주소
+     * @return 이메일에 해당하는 {@link User} 객체 반환
+     * @throws {@link AuthException} 사용자가 존재하지 않는다면 {@link AuthExceptionCode#USER_NOT_FOUND} 예외를 발생
+     */
+    User findUserOrThrow(String email);
+
+    /**
+     * 사용자가 존재하지 않으면 새로 생성하고 저장하는 메서드
+     *
+     * @param email 사용자의 이메일
+     * @param authType 소셜 로그인 타입 (예: {@link SocialLoginType#GOOGLE}, {@link SocialLoginType#KAKAO})
+     * @return 생성되거나 기존에 존재하던 {@link User} 객체
+     */
     User createUserIfNotExists(String email, SocialLoginType authType);
 }

--- a/CultureSpot-Domain/src/main/java/com/culturespot/culturespotdomain/core/user/service/UserService.java
+++ b/CultureSpot-Domain/src/main/java/com/culturespot/culturespotdomain/core/user/service/UserService.java
@@ -39,4 +39,6 @@ public interface UserService{
      * @return 생성되거나 기존에 존재하던 {@link User} 객체
      */
     User createUserIfNotExists(String email, SocialLoginType authType);
+
+    public void updateLastLoginAt(User user);
 }

--- a/CultureSpot-Domain/src/main/java/com/culturespot/culturespotdomain/core/user/service/UserServiceImpl.java
+++ b/CultureSpot-Domain/src/main/java/com/culturespot/culturespotdomain/core/user/service/UserServiceImpl.java
@@ -18,19 +18,29 @@ import java.util.stream.Collectors;
 public class UserServiceImpl implements UserService {
     private final UserRepository userRepository;
 
+    /**
+     * 주어진 이메일에 해당하는 사용자를 조회
+     * <p>
+     * 사용자가 존재하면 해당 {@link User} 객체를 반환하고, 존재하지 않으면 {@link AuthException}을 발생시킵니다.
+     * </p>
+     *
+     * @param email 사용자의 이메일 주소
+     * @return 이메일에 해당하는 {@link User} 객체 반환
+     * @throws {@link AuthException} 사용자가 존재하지 않는다면 {@link AuthExceptionCode#USER_NOT_FOUND} 예외를 발생
+     */
     @Override
     @Transactional(readOnly = true)
     public User findUserOrThrow(String email) {
-        System.out.println(".........email......." + email);
         return userRepository.findByEmail(email)
                 .orElseThrow(() -> new AuthException(AuthExceptionCode.USER_NOT_FOUND));
     }
 
     /**
-     * 사용자가 존재하지 않으면 새로 생성하고 저장하는 메서드
+     * 사용자가 존재하지 않으면 새로 생성하고 저장
+     *
      * @param email 사용자의 이메일
-     * @param authType 소셜 로그인 타입 (GOOGLE, KAKAO 등)
-     * @return User 엔티티
+     * @param authType 소셜 로그인 타입 (예: {@link SocialLoginType#GOOGLE}, {@link SocialLoginType#KAKAO})
+     * @return 생성되거나 기존에 존재하던 {@link User} 객체
      */
     @Override
     public User createUserIfNotExists(String email, SocialLoginType authType) {
@@ -46,6 +56,15 @@ public class UserServiceImpl implements UserService {
                 });
     }
 
+    /**
+     *  사용자가 갖고 있는 권한 조회
+     * <p>
+     * 권한 이름은 {@link com.culturespot.culturespotdomain.core.role.entity.UserRoleType} enum의 name() 값을 기준으로 하며,
+     * 중복 없이 {@link Set} 형태로 반환됩니다.
+     * </p>
+     * @param user 사용자 정보를 담고 있는 {@link User} 객체
+     * @return 사용자가 가진 권한 이름의 집합 (예: "USER", "ADMIN")
+     * */
     @Override
     public Set<String> getRoleNames(User user) {
         return user.getRoles().stream()

--- a/CultureSpot-Domain/src/main/java/com/culturespot/culturespotdomain/core/user/service/UserServiceImpl.java
+++ b/CultureSpot-Domain/src/main/java/com/culturespot/culturespotdomain/core/user/service/UserServiceImpl.java
@@ -9,6 +9,7 @@ import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -70,5 +71,16 @@ public class UserServiceImpl implements UserService {
         return user.getRoles().stream()
                 .map(userRole -> userRole.getRole().getRoleType().name())
                 .collect(Collectors.toSet());
+    }
+
+    /**
+     *  사용자의 최근 접속시간 업데이트
+     *
+     * @param user 사용자 정보를 담고 있는 {@link User} 객체
+     * */
+    @Override
+    @Transactional
+    public void updateLastLoginAt(User user) {
+        userRepository.updateLastLoginAt(user.getId(), LocalDateTime.now());
     }
 }

--- a/CultureSpot-Domain/src/main/resources/domain-application-prod.yml
+++ b/CultureSpot-Domain/src/main/resources/domain-application-prod.yml
@@ -21,14 +21,11 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
-      naming:
-        physical-strategy: org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy
     show-sql: true
     properties:
-      hibernate:
-        format_sql: true
-        physical_naming_strategy: org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy
+      hibernate.format_sql: true
     defer-datasource-initialization: true
+
   jwt:
     private-key-pem: ${JWT_PRIVATE_KEY}
     public-key-pem: ${JWT_PUBLIC_KEY}

--- a/CultureSpot-Domain/src/main/resources/domain-application.yml
+++ b/CultureSpot-Domain/src/main/resources/domain-application.yml
@@ -19,9 +19,13 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
+      naming:
+        physical-strategy: org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy
     show-sql: true
     properties:
-      hibernate.format_sql: true
+      hibernate:
+        format_sql: true
+        physical_naming_strategy: org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy
     defer-datasource-initialization: true
 
   jwt:
@@ -29,3 +33,10 @@ spring:
     public-key-pem: ${JWT_PUBLIC_KEY}
     access-expiration-time: 1800  # Access Token 만료 시간 (30분)
     refresh-expiration-time: 1209600  # Refresh Token 만료 시간 (14일)
+
+  batch:
+    jdbc:
+      initialize-schema: never
+
+discord:
+  webhook: ${DISCORD_WEBHOOK_URL}

--- a/CultureSpot-ServiceApi/src/main/java/com/culturespot/culturespotserviceapi/core/auth/controller/AuthController.java
+++ b/CultureSpot-ServiceApi/src/main/java/com/culturespot/culturespotserviceapi/core/auth/controller/AuthController.java
@@ -11,8 +11,8 @@ import org.springframework.web.bind.annotation.*;
 
 /*
 *   ✅ 구글 소셜 로그인 요청 URI : http://localhost:8080/oauth2/authorization/google
+*   ✅ 카카오 소셜 로그인 요청 URI : http://localhost:8080/oauth2/authorization/kakao
 *   ✅ 소셜 로그인 통합 로그아웃 요청 URI : POST /api/public/logout
-*
 * */
 
 @RestController

--- a/CultureSpot-ServiceApi/src/main/java/com/culturespot/culturespotserviceapi/core/auth/dto/LoginUser.java
+++ b/CultureSpot-ServiceApi/src/main/java/com/culturespot/culturespotserviceapi/core/auth/dto/LoginUser.java
@@ -1,0 +1,12 @@
+package com.culturespot.culturespotserviceapi.core.auth.dto;
+
+import com.culturespot.culturespotdomain.core.user.entity.SocialLoginType;
+
+public record LoginUser(
+        Long userId,
+        String username,
+        SocialLoginType platform,
+        String email,
+        int profileCode
+) {}
+

--- a/CultureSpot-ServiceApi/src/main/java/com/culturespot/culturespotserviceapi/core/auth/dto/response/LoginFailResponse.java
+++ b/CultureSpot-ServiceApi/src/main/java/com/culturespot/culturespotserviceapi/core/auth/dto/response/LoginFailResponse.java
@@ -1,0 +1,7 @@
+package com.culturespot.culturespotserviceapi.core.auth.dto.response;
+
+public record LoginFailResponse (
+        int code,
+        String message
+){
+}

--- a/CultureSpot-ServiceApi/src/main/java/com/culturespot/culturespotserviceapi/core/auth/dto/response/LoginSuccessResponse.java
+++ b/CultureSpot-ServiceApi/src/main/java/com/culturespot/culturespotserviceapi/core/auth/dto/response/LoginSuccessResponse.java
@@ -1,0 +1,8 @@
+package com.culturespot.culturespotserviceapi.core.auth.dto.response;
+
+import com.culturespot.culturespotserviceapi.core.auth.dto.LoginUser;
+
+public record LoginSuccessResponse(
+        LoginUser user
+) {
+}

--- a/CultureSpot-ServiceApi/src/main/java/com/culturespot/culturespotserviceapi/core/auth/handler/OAuth2AuthenticationFailureHandler.java
+++ b/CultureSpot-ServiceApi/src/main/java/com/culturespot/culturespotserviceapi/core/auth/handler/OAuth2AuthenticationFailureHandler.java
@@ -1,0 +1,38 @@
+package com.culturespot.culturespotserviceapi.core.auth.handler;
+
+import com.culturespot.culturespotdomain.core.global.exception.AuthExceptionCode;
+import com.culturespot.culturespotdomain.core.global.exception.ExceptionStatusMapper;
+import com.culturespot.culturespotserviceapi.core.auth.dto.response.LoginFailResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationFailureHandler {
+
+    @Override
+    public void onAuthenticationFailure(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException exception
+    ) throws IOException {
+        AuthExceptionCode authExceptionCode = AuthExceptionCode.CANCELLED_AUTHENTICATION;
+        HttpStatus status = ExceptionStatusMapper.getAuthStatus(authExceptionCode.getCode());
+
+        response.setStatus(status.value());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        LoginFailResponse failResponse = new LoginFailResponse(authExceptionCode.getCode(), authExceptionCode.getMessage());
+
+        new ObjectMapper()
+                .writeValue(response.getWriter(), failResponse);
+    }
+}
+

--- a/CultureSpot-ServiceApi/src/main/java/com/culturespot/culturespotserviceapi/core/auth/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/CultureSpot-ServiceApi/src/main/java/com/culturespot/culturespotserviceapi/core/auth/handler/OAuth2AuthenticationSuccessHandler.java
@@ -71,7 +71,7 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
 
-        // ✅ 응답 객체 생성
+        // ✅ 응답 객체 생성 & 사용자 최신 로그인 시간 업데이트
         LoginSuccessResponse responseDto = oAuth2LoginHandler.handle(registrationId, email);
 
         new ObjectMapper()

--- a/CultureSpot-ServiceApi/src/main/java/com/culturespot/culturespotserviceapi/core/auth/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/CultureSpot-ServiceApi/src/main/java/com/culturespot/culturespotserviceapi/core/auth/handler/OAuth2AuthenticationSuccessHandler.java
@@ -4,7 +4,7 @@ import com.culturespot.culturespotdomain.core.refreshToken.service.RefreshTokenS
 import com.culturespot.culturespotdomain.core.user.entity.SocialLoginType;
 import com.culturespot.culturespotdomain.core.global.jwt.JwtTokenManager;
 import com.culturespot.culturespotserviceapi.core.auth.dto.response.LoginSuccessResponse;
-import com.culturespot.culturespotserviceapi.core.auth.strategy.OAuth2LoginHandler;
+import com.culturespot.culturespotserviceapi.core.auth.strategy.OAuth2LoginSuccessHandler;
 import com.culturespot.culturespotserviceapi.core.global.utils.CookieUtils;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.Cookie;
@@ -25,18 +25,18 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
     private final int REFRESH_TOKEN_EXPIRATION;
     private final JwtTokenManager jwtTokenManager;
     private final RefreshTokenService refreshTokenService;
-    private final OAuth2LoginHandler oAuth2LoginHandler;
+    private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
 
     public OAuth2AuthenticationSuccessHandler(
             @Value("${spring.jwt.refresh-expiration-time}") final int REFRESH_TOKEN_EXPIRATION,
             JwtTokenManager jwtTokenManager,
             RefreshTokenService refreshTokenService,
-            OAuth2LoginHandler oAuth2LoginHandler
+            OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler
     ) {
         this.jwtTokenManager = jwtTokenManager;
         this.REFRESH_TOKEN_EXPIRATION = REFRESH_TOKEN_EXPIRATION;
         this.refreshTokenService = refreshTokenService;
-        this.oAuth2LoginHandler = oAuth2LoginHandler;
+        this.oAuth2LoginSuccessHandler = oAuth2LoginSuccessHandler;
     }
 
     @Override
@@ -72,7 +72,7 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
         response.setCharacterEncoding("UTF-8");
 
         // ✅ 응답 객체 생성 & 사용자 최신 로그인 시간 업데이트
-        LoginSuccessResponse responseDto = oAuth2LoginHandler.handle(registrationId, email);
+        LoginSuccessResponse responseDto = oAuth2LoginSuccessHandler.handle(registrationId, email);
 
         new ObjectMapper()
                 .writeValue(response.getWriter(), responseDto);

--- a/CultureSpot-ServiceApi/src/main/java/com/culturespot/culturespotserviceapi/core/auth/strategy/LoginContext.java
+++ b/CultureSpot-ServiceApi/src/main/java/com/culturespot/culturespotserviceapi/core/auth/strategy/LoginContext.java
@@ -1,0 +1,8 @@
+package com.culturespot.culturespotserviceapi.core.auth.strategy;
+
+public record LoginContext(
+        String registrationId,
+        String email
+) {
+}
+

--- a/CultureSpot-ServiceApi/src/main/java/com/culturespot/culturespotserviceapi/core/auth/strategy/OAuth2LoginHandler.java
+++ b/CultureSpot-ServiceApi/src/main/java/com/culturespot/culturespotserviceapi/core/auth/strategy/OAuth2LoginHandler.java
@@ -34,11 +34,13 @@ public class OAuth2LoginHandler {
 
     private LoginSuccessResponse handleGoogle(LoginContext ctx) {
         User user = userService.findUserOrThrow(ctx.email());
+        userService.updateLastLoginAt(user);
         return toResponse(user);
     }
 
     private LoginSuccessResponse handleKakao(LoginContext ctx) {
         User user = userService.findUserOrThrow(ctx.email());
+        userService.updateLastLoginAt(user);
         return toResponse(user);
     }
 

--- a/CultureSpot-ServiceApi/src/main/java/com/culturespot/culturespotserviceapi/core/auth/strategy/OAuth2LoginHandler.java
+++ b/CultureSpot-ServiceApi/src/main/java/com/culturespot/culturespotserviceapi/core/auth/strategy/OAuth2LoginHandler.java
@@ -1,0 +1,61 @@
+package com.culturespot.culturespotserviceapi.core.auth.strategy;
+
+import com.culturespot.culturespotdomain.core.global.exception.AuthException;
+import com.culturespot.culturespotdomain.core.global.exception.AuthExceptionCode;
+import com.culturespot.culturespotdomain.core.user.entity.User;
+import com.culturespot.culturespotdomain.core.user.service.UserService;
+import com.culturespot.culturespotserviceapi.core.auth.dto.LoginUser;
+import com.culturespot.culturespotserviceapi.core.auth.dto.response.LoginSuccessResponse;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.function.Function;
+
+@Component
+public class OAuth2LoginHandler {
+
+    private final UserService userService;
+
+    private final Map<String, Function<LoginContext, LoginSuccessResponse>> loginStrategies;
+
+    public OAuth2LoginHandler(UserService userService) {
+        this.userService = userService;
+        this.loginStrategies = Map.of(
+                "google", this::handleGoogle,
+                "kakao", this::handleKakao
+        );
+    }
+
+    public LoginSuccessResponse handle(String registrationId, String email) {
+        return loginStrategies
+                .getOrDefault(registrationId, this::handleDefault)
+                .apply(new LoginContext(registrationId, email));
+    }
+
+    private LoginSuccessResponse handleGoogle(LoginContext ctx) {
+        User user = userService.findUserOrThrow(ctx.email());
+        return toResponse(user);
+    }
+
+    private LoginSuccessResponse handleKakao(LoginContext ctx) {
+        User user = userService.findUserOrThrow(ctx.email());
+        return toResponse(user);
+    }
+
+    private LoginSuccessResponse handleDefault(LoginContext ctx) {
+        throw new AuthException(AuthExceptionCode.UNSUPPORTED_LOGIN_METHOD);
+    }
+
+    private LoginSuccessResponse toResponse(User user) {
+        return new LoginSuccessResponse(
+                new LoginUser(
+                        user.getId(),
+                        user.getNickname(),
+                        user.getAuthType(),
+                        user.getEmail(),
+                        user.getProfileCode()
+                )
+        );
+    }
+}
+

--- a/CultureSpot-ServiceApi/src/main/java/com/culturespot/culturespotserviceapi/core/auth/strategy/OAuth2LoginSuccessHandler.java
+++ b/CultureSpot-ServiceApi/src/main/java/com/culturespot/culturespotserviceapi/core/auth/strategy/OAuth2LoginSuccessHandler.java
@@ -12,13 +12,13 @@ import java.util.Map;
 import java.util.function.Function;
 
 @Component
-public class OAuth2LoginHandler {
+public class OAuth2LoginSuccessHandler {
 
     private final UserService userService;
 
     private final Map<String, Function<LoginContext, LoginSuccessResponse>> loginStrategies;
 
-    public OAuth2LoginHandler(UserService userService) {
+    public OAuth2LoginSuccessHandler(UserService userService) {
         this.userService = userService;
         this.loginStrategies = Map.of(
                 "google", this::handleGoogle,

--- a/CultureSpot-ServiceApi/src/main/java/com/culturespot/culturespotserviceapi/core/auth/userInfo/CustomOAuth2User.java
+++ b/CultureSpot-ServiceApi/src/main/java/com/culturespot/culturespotserviceapi/core/auth/userInfo/CustomOAuth2User.java
@@ -9,10 +9,12 @@ import java.util.Map;
 public class CustomOAuth2User implements OAuth2User {
 
     private final OAuth2User oAuth2User;
+    private final String email; // principalName으로 사용
     private final Collection<? extends GrantedAuthority> authorities;
 
-    public CustomOAuth2User(OAuth2User oAuth2User, Collection<? extends GrantedAuthority> authorities) {
+    public CustomOAuth2User(OAuth2User oAuth2User, String email, Collection<? extends GrantedAuthority> authorities) {
         this.oAuth2User = oAuth2User;
+        this.email = email;
         this.authorities = authorities;
     }
 
@@ -28,6 +30,10 @@ public class CustomOAuth2User implements OAuth2User {
 
     @Override
     public String getName() {
-        return oAuth2User.getAttribute("email"); // email을 PK로 사용
+        // principalName이 null 또는 빈 문자열이면 Spring Security에서 예외 발생
+        if (email == null || email.isBlank()) {
+            throw new IllegalArgumentException("OAuth2User의 principalName(email)이 비어있습니다.");
+        }
+        return email;
     }
 }

--- a/CultureSpot-ServiceApi/src/main/java/com/culturespot/culturespotserviceapi/core/auth/userInfo/CustomOAuth2UserService.java
+++ b/CultureSpot-ServiceApi/src/main/java/com/culturespot/culturespotserviceapi/core/auth/userInfo/CustomOAuth2UserService.java
@@ -8,6 +8,7 @@ import com.culturespot.culturespotdomain.core.role.repository.RoleRepository;
 import com.culturespot.culturespotdomain.core.user.repository.UserRoleRepository;
 import com.culturespot.culturespotdomain.core.user.entity.User;
 import com.culturespot.culturespotdomain.core.user.repository.UserRepository;
+import com.culturespot.culturespotdomain.core.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -20,12 +21,13 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final UserService userService;
 
     private final UserRepository userRepository;
     private final RoleRepository roleRepository;
@@ -56,12 +58,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     }
 
     private User createNewUser(String email, SocialLoginType authType) {
-        User createUser = User.builder()
-                .email(email)
-                .nickname(email)
-                .password(UUID.randomUUID().toString()) // 랜덤 비밀번호 설정
-                .authType(authType)
-                .build();
+        User createUser = userService.createUser(email, authType);
 
         // 기본 권한 부여
         Role role = roleRepository.findByRoleType(UserRoleType.USER)

--- a/CultureSpot-ServiceApi/src/main/java/com/culturespot/culturespotserviceapi/core/global/security/endpoint/EndpointType.java
+++ b/CultureSpot-ServiceApi/src/main/java/com/culturespot/culturespotserviceapi/core/global/security/endpoint/EndpointType.java
@@ -11,7 +11,6 @@ public enum EndpointType {
     public static final String PUBLIC_PATH = "/api/public";
     public static final String USER_PATH = "/api/users";
     public static final String ADMIN_PATH = "/api/admins";
-    public static final String GOOGLE_LOGIN_PATH = "/login/oauth2/code/google"; // Spring Security에서 제공하는 리다이렉션 URI
 
     EndpointType(String path) {
         this.path = path;


### PR DESCRIPTION
## 이슈 번호, 혹은 추가한 기능에 대해 설명해주세요.

[[BE] 사용자가 카카오 소셜 로그인을 할 수 있도록 한다. #CUL-85](https://chopinoff.atlassian.net/browse/CUL-85?atlOrigin=eyJpIjoiOWNkOGRmYzdhOTYwNDkyNWFlNTlhNDJlMWI1ZmJjMzIiLCJwIjoiaiJ9)

## 작업 상세 내용

- [ ] 사용자가 카카오 로그인을 할 수 있도록 한다.

## 기타 내용
[CultureSpot-Backend-Secrets](https://github.com/culturespot/CultureSpot-Backend-Secrets)의 아래 내용이 변경되었습니다.
- 변경 내용
  - `CultureSpot-ServiceApi/src/main/resources/application.yml`
    - Kakao 소셜 로그인 도입으로 인해 설정과 관련한 변경 발생
  - `env/serviceApi-module.env`
    - Kakao 소셜 로그인 도입으로 클라이언트 id의 추가
  - `env/domain-module.env`
    - `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET` 위치가 부적합하여 삭제 후 `env/serviceApi-module.env`로 이동 (업데이트 하기 전부터 중복으로 존재했습니다) 
 - 변경 사유
   -  Kakao 클라이언트 id 추가로 인한 변경 발생