### PR TITLE
[fix] read PEM keys from file system path instead of classpath Resource

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,5 @@
 name: Deploy
 
-
 on:
   workflow_run:
     workflows: [ "Build" ]

--- a/CultureSpot-Domain/src/main/java/com/culturespot/culturespotdomain/core/global/config/KeyConfig.java
+++ b/CultureSpot-Domain/src/main/java/com/culturespot/culturespotdomain/core/global/config/KeyConfig.java
@@ -1,11 +1,11 @@
 package com.culturespot.culturespotdomain.core.global.config;
 
 import com.culturespot.culturespotdomain.core.global.jwt.KeyBuilder;
+import java.io.FileInputStream;
+import java.io.InputStream;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.io.Resource;
-import org.springframework.util.StreamUtils;
 
 import java.nio.charset.StandardCharsets;
 import java.security.PrivateKey;
@@ -15,14 +15,14 @@ import java.security.PublicKey;
 public class KeyConfig {
 
     @Value("${spring.jwt.public-key-pem}")
-    private Resource publicKeyFile;
+    private String publicKeyPath;
 
     @Value("${spring.jwt.private-key-pem}")
-    private Resource privateKeyFile;
+    private String privateKeyPath;
 
     @Bean
     public PublicKey publicKey() throws Exception {
-        String base64PublicKey = readKeyFromFile(publicKeyFile);
+        String base64PublicKey = readKeyFromFile(publicKeyPath);
         return KeyBuilder.builder()
                 .setPublicKey(base64PublicKey)
                 .build()
@@ -31,7 +31,7 @@ public class KeyConfig {
 
     @Bean
     public PrivateKey privateKey() throws Exception {
-        String base64PrivateKey = readKeyFromFile(privateKeyFile);
+        String base64PrivateKey = readKeyFromFile(privateKeyPath);
         return KeyBuilder.builder()
                 .setPrivateKey(base64PrivateKey)
                 .build()
@@ -41,9 +41,19 @@ public class KeyConfig {
     /**
      * 파일에서 Base64로 인코딩된 키 값을 읽어오는 메서드
      */
-    private String readKeyFromFile(Resource resource) throws Exception {
-        byte[] keyBytes = StreamUtils.copyToByteArray(resource.getInputStream());
-        return new String(keyBytes, StandardCharsets.UTF_8);
+//    private String readKeyFromFile(Resource resource) throws Exception {
+//        byte[] keyBytes = StreamUtils.copyToByteArray(resource.getInputStream());
+//        return new String(keyBytes, StandardCharsets.UTF_8);
+//    }
+    private String readKeyFromFile(String path) throws Exception {
+        // "file:" prefix가 있으면 제거
+        if (path.startsWith("file:")) {
+            path = path.substring(5);
+        }
+
+        try (InputStream inputStream = new FileInputStream(path)) {
+            return new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+        }
     }
 }
 


### PR DESCRIPTION
## 📍작업 상세 내용

배포 중 pem 키 주입에 대해 오류를 해결하고 있습니다. 기존 비즈니스 로직의 변경이 있어서 PR 리뷰를 요청합니다.
(해당 내용이 반영되었을 때 현재 오류가 해결될지는 병합 후 컨테이너를 다시 확인해봐야 할 것 같습니다.)
(추가로 secrets 에서 `domain-module.env` 파일의 `JWT_PRIVATE_KEY`, `JWT_PUBLIC_KEY`의 경로 변경이 있습니다.)

### 문제 상황

ec2 내부 컨테이너가 다운된 후 Spring 실행 로그를 살펴보니 다음처럼 PEM 내용이 그대로 출력되었습니다.
> Caused by: java.io.FileNotFoundException: Could not open ServletContext resource [/-----BEGIN PRIVATE KEY-----
...(PRIVATE KEY 내용)
-----END PRIVATE KEY-----]

### 원인 분석

로그에 PEM 내용이 찍혔다는 건, 파일의 경로가 아니라 **내용**이 들어갔다고 판단했습니다.

즉 다음과 같습니다.
- .env → spring.jwt.private-key-pem → @Value("${...}") → Resource 타입으로 주입됨.
- 그런데 이 Resource를 쓸 때 `resource.getInputStream()` 등을 호출하지 않고, `.getFilename()` 또는 `.toString()`을 해서 **값 자체가 문자열로 해석됨**
- 즉, PEM 내용을 **경로 문자열처럼 해석**하려다 못 읽겠다 하고 죽은 것

현재 `.env` 파일에는 분명히 경로(`JWT_PRIVATE_KEY=file:/app/keys/private.pem`)가 잘 주입되고 있습니다.
따라서 KeyConfig에서 Resource 로 받는 것에 대해, `.env`에서 내용을 넣은 뒤 그걸 문자열로 받아버리고, 이를 파일처럼 쓰려다 실패한 것으로 추정하였습니다.

## 📍리뷰 요청 내용

- 해당 코드 변경에 대해 작업하신 은철 님의 리뷰와, 현재 오류 해결 방향에 대해 창권 님의 피드백을 주시면 감사드리겠습니다!