### PR TITLE
[CUL-265] fix: Update CORS settings for local environment on port 3000

### DIFF
--- a/CultureSpot-ServiceApi/src/main/java/com/culturespot/culturespotserviceapi/core/global/security/config/CorsConfig.java
+++ b/CultureSpot-ServiceApi/src/main/java/com/culturespot/culturespotserviceapi/core/global/security/config/CorsConfig.java
@@ -17,6 +17,7 @@ public class CorsConfig {
 
         configuration.setAllowedOrigins(List.of(
                 "https://localhost:3000",
+                "http://localhost:3000",
                 "http://culturespot.com",
                 "https://culturespot.com"
         ));


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/d116c0c7-339a-4052-b6b3-6969af2cc636)

프론트에서 CORS 문제를 겪고 있었고 이를 해결했습니다.
단순히 `http://localhost:3000`를 추가해준 부분이라 프론트 측 작업을 위해 병합진행하겠습니다.